### PR TITLE
Freeze the now datetime on import and module initialization

### DIFF
--- a/dc_etl/__init__.py
+++ b/dc_etl/__init__.py
@@ -1,2 +1,3 @@
 import numpy as np
+
 NP_DATETIME_NOW = np.datetime64("now")


### PR DESCRIPTION
To prevent issues with running code during change of year