### PR TITLE
feat: a better filespec interface

### DIFF
--- a/dc_etl/__init__.py
+++ b/dc_etl/__init__.py
@@ -2,4 +2,4 @@ import yaml
 
 from . import filespec
 
-yaml.add_constructor("!filespec", filespec.File._load_yaml)
+yaml.add_constructor("!filespec", filespec.FileSpec._load_yaml)

--- a/dc_etl/combine.py
+++ b/dc_etl/combine.py
@@ -8,7 +8,7 @@ import xarray
 
 from kerchunk import combine
 
-from .filespec import File
+from .filespec import FileSpec
 
 
 class Combiner(abc.ABC):
@@ -19,7 +19,7 @@ class Combiner(abc.ABC):
     """
 
     @abc.abstractmethod
-    def __call__(self, sources: list[File]) -> xarray.Dataset:
+    def __call__(self, sources: list[FileSpec]) -> xarray.Dataset:
         """Generate a MultiZarr from single Zarr JSONs.
 
         Parameters
@@ -73,7 +73,7 @@ class DefaultCombiner(Combiner):
 
     def __init__(
         self,
-        output_folder: File,
+        output_folder: FileSpec,
         concat_dims: list[str],
         identical_dims: list[str],
         preprocessors: list[CombinePreprocessor] = (),
@@ -85,7 +85,7 @@ class DefaultCombiner(Combiner):
         self.preprocessors = preprocessors
         self.postprocessors = postprocessors
 
-    def __call__(self, sources: list[File]) -> xarray.Dataset:
+    def __call__(self, sources: list[FileSpec]) -> xarray.Dataset:
         """Implementation of meth:`Combiner.__call__`.
 
         Calls `kerchunk.MultiZarrToZarr`.

--- a/dc_etl/config.py
+++ b/dc_etl/config.py
@@ -8,7 +8,7 @@ from importlib.metadata import entry_points
 import yaml
 
 from dc_etl import errors
-from dc_etl.filespec import File
+from dc_etl.filespec import FileSpec
 
 _MISSING = object()
 
@@ -19,7 +19,7 @@ class _Configuration(collections.UserDict):
     """
 
     @classmethod
-    def from_yaml(cls, path: File):
+    def from_yaml(cls, path: FileSpec):
         data = yaml.load(path.open(), Loader=yaml.Loader)
         return cls(data, path.path, [])
 

--- a/dc_etl/extract.py
+++ b/dc_etl/extract.py
@@ -1,13 +1,13 @@
 import abc
 
-from dc_etl.filespec import File
+from dc_etl.filespec import FileSpec
 
 
 class Extractor(abc.ABC):
     """Responsible for taking a raw source file and turning it into a single Zarr JSON."""
 
     @abc.abstractmethod
-    def extract(self, source: File) -> File:
+    def extract(self, source: FileSpec) -> FileSpec:
         """Extract a source data file into a single Zarr JSON file.
 
         Parameters

--- a/dc_etl/extractors/netcdf.py
+++ b/dc_etl/extractors/netcdf.py
@@ -3,7 +3,7 @@ import orjson
 from kerchunk import hdf
 
 from dc_etl.extract import Extractor
-from dc_etl.filespec import File
+from dc_etl.filespec import FileSpec
 
 
 class NetCDFExtractor(Extractor):
@@ -20,11 +20,11 @@ class NetCDFExtractor(Extractor):
         inline data. Default is 5000.
     """
 
-    def __init__(self, output_folder: File = None, inline_threshold: int = 5000):
+    def __init__(self, output_folder: FileSpec = None, inline_threshold: int = 5000):
         self.output_folder = output_folder
         self.inline_threshold = inline_threshold
 
-    def extract(self, source: File) -> File:
+    def extract(self, source: FileSpec) -> FileSpec:
         """Implementation of :meth:`Extractor.extract`"""
         if self.output_folder:
             dest = (self.output_folder / source.name).with_suffix("json")

--- a/dc_etl/fetch.py
+++ b/dc_etl/fetch.py
@@ -40,7 +40,7 @@ class Fetcher(abc.ABC):
         """
 
     @abc.abstractmethod
-    def fetch(self, span: Timespan) -> typing.Generator[filespec.File, None, None]:
+    def fetch(self, span: Timespan) -> typing.Generator[filespec.FileSpec, None, None]:
         """Extract any files from the remote data provider corresponding to the given timespan.
 
         Data files from the data provider that correspond to the given timespan will be opened using xarray and yielded

--- a/dc_etl/fetchers/cpc.py
+++ b/dc_etl/fetchers/cpc.py
@@ -10,7 +10,7 @@ import xarray
 
 from dc_etl.errors import MissingConfigurationError
 from dc_etl.fetch import Fetcher, Timespan
-from dc_etl.filespec import File
+from dc_etl.filespec import FileSpec
 
 _GLOB = {
     "global_precip": ["/Datasets/cpc_global_precip/precip.*.nc"],
@@ -34,7 +34,7 @@ class CPCFetcher(Fetcher):
         Optionally, a writable folder where downloaded files can be cached.
     """
 
-    def __init__(self, dataset: str, cache: File | None = None):
+    def __init__(self, dataset: str, cache: FileSpec | None = None):
         glob = _GLOB.get(dataset)
         if glob is None:
             raise MissingConfigurationError(f"Unrecognized dataset: {dataset}, valid values are {', '.join(_GLOB)}")
@@ -82,7 +82,7 @@ class CPCFetcher(Fetcher):
             for _ in self.fetch(span):
                 pass
 
-    def fetch(self, span: Timespan) -> Generator[File, None, None]:
+    def fetch(self, span: Timespan) -> Generator[FileSpec, None, None]:
         """Implementation of :meth:`Fetcher.fetch`"""
         start = span.start.astype(object).year
         end = span.end.astype(object).year
@@ -94,7 +94,7 @@ class CPCFetcher(Fetcher):
         """Get a FileSpec for the path, using the cache if configured."""
         # Not using cache
         if not self._cache:
-            return File(self._fs, path)
+            return FileSpec(self._fs, path)
 
         # Check cache
         cache_path = self._cache_path(path)
@@ -109,7 +109,7 @@ class CPCFetcher(Fetcher):
         """Get a FileSpec for the year, using the cache if configured."""
         # Not using cache
         if not self._cache:
-            return File(self._fs, self._year_to_path(year))
+            return FileSpec(self._fs, self._year_to_path(year))
 
         # Check cache
         if self._cache.exists():

--- a/dc_etl/filespec.py
+++ b/dc_etl/filespec.py
@@ -5,8 +5,8 @@ import typing
 import fsspec
 
 
-def file(path, fs_name="file", *fs_args, **fs_kwargs) -> File:
-    """Get a File instance which combines an fsspec Filesystem with a path component.
+def file(path, fs_name="file", *fs_args, **fs_kwargs) -> FileSpec:
+    """Get a FileSpec instance which combines an fsspec Filesystem with a path component.
 
     Parameters
     ----------
@@ -26,14 +26,14 @@ def file(path, fs_name="file", *fs_args, **fs_kwargs) -> File:
 
     Returns
     -------
-    File:
-        The File instance.
+    FileSpec:
+        The FileSpec instance.
     """
     fs = fsspec.filesystem(fs_name, *fs_args, **fs_kwargs)
-    return File(fs, str(path))
+    return FileSpec(fs, str(path))
 
 
-class File(typing.NamedTuple):
+class FileSpec(typing.NamedTuple):
     """Encapsulates both the location of a file and its fsspec "filesystem"."""
 
     fs: fsspec.AbstractFileSystem
@@ -45,7 +45,7 @@ class File(typing.NamedTuple):
     """
 
     @classmethod
-    def _load_yaml(cls, loader, node) -> File:
+    def _load_yaml(cls, loader, node) -> FileSpec:
         from .config import _Configuration  # Avoid circular import
 
         config = _Configuration(loader.construct_mapping(node), loader.name, [])
@@ -61,7 +61,7 @@ class File(typing.NamedTuple):
         """A passthrough to `fsspec.AbstractFilesystem.open` using the path from this instance."""
         return self.fs.open(self.path, mode)
 
-    def with_suffix(self, suffix: str) -> File:
+    def with_suffix(self, suffix: str) -> FileSpec:
         """Returns a new FileSpec with the file suffix changed to `suffix`.
 
         If there is no file suffix, one is added.
@@ -84,7 +84,7 @@ class File(typing.NamedTuple):
             if sep < dot:
                 path = path[:dot]
 
-        return File(self.fs, f"{path}.{suffix.lstrip('.')}")
+        return FileSpec(self.fs, f"{path}.{suffix.lstrip('.')}")
 
     @property
     def name(self) -> str:
@@ -96,7 +96,7 @@ class File(typing.NamedTuple):
 
         return path
 
-    def __truediv__(self, other: str) -> File:
+    def __truediv__(self, other: str) -> FileSpec:
         """Overloads the `/` (division) operator to allow new paths to be created by appending new path elements,
         much as `pathlib.Path` does in the standard library.
         """
@@ -104,7 +104,7 @@ class File(typing.NamedTuple):
         return type(self)(self.fs, path)
 
     @property
-    def parent(self) -> File:
+    def parent(self) -> FileSpec:
         split = self.path.rstrip("/").rsplit("/", 1)
         if len(split) == 2:
             parent, _ = split

--- a/dc_etl/ipld/local_file.py
+++ b/dc_etl/ipld/local_file.py
@@ -1,13 +1,13 @@
 from multiformats import CID
 
-from dc_etl.filespec import File
+from dc_etl.filespec import FileSpec
 from dc_etl.ipld.loader import IPLDPublisher
 
 
 class LocalFileIPLDPublisher(IPLDPublisher):
     """Publishes CID of dataset to a local file."""
 
-    def __init__(self, path: File):
+    def __init__(self, path: FileSpec):
         self.path = path
 
     def publish(self, cid: CID):

--- a/dc_etl/pipeline.py
+++ b/dc_etl/pipeline.py
@@ -6,7 +6,7 @@ from dc_etl.combine import Combiner
 from dc_etl.config import _Configuration
 from dc_etl.extract import Extractor
 from dc_etl.fetch import Fetcher
-from dc_etl.filespec import File, file
+from dc_etl.filespec import FileSpec, file
 from dc_etl.load import Loader
 from dc_etl.transform import Transformer, identity
 
@@ -29,9 +29,9 @@ class Pipeline:
     """
 
     @classmethod
-    def from_yaml(cls, path: pathlib.Path | File) -> Pipeline:
+    def from_yaml(cls, path: pathlib.Path | FileSpec) -> Pipeline:
         """Import configuration from a yaml file."""
-        if not isinstance(path, File):
+        if not isinstance(path, FileSpec):
             path = file(path)
 
         config = _Configuration.from_yaml(path)

--- a/tests/system/extractors/test_netcdf.py
+++ b/tests/system/extractors/test_netcdf.py
@@ -4,7 +4,7 @@ import xarray
 from dc_etl.extractors.netcdf import NetCDFExtractor
 from dc_etl.fetch import Timespan
 from dc_etl.fetchers.cpc import CPCFetcher
-from dc_etl.filespec import File
+from dc_etl.filespec import FileSpec
 
 from tests.conftest import npdate
 
@@ -78,7 +78,7 @@ class TestNetCDFExtractor:
             assert len(output.fs.glob(f"{output.path}/*{year}.json")) == 1
 
 
-def open_dataset(source: File):
+def open_dataset(source: FileSpec):
     return xarray.open_dataset(
         "reference://",
         engine="zarr",

--- a/tests/unit/test_filespec.py
+++ b/tests/unit/test_filespec.py
@@ -35,7 +35,7 @@ class TestFileSpec:
         node = object()
         fsspec = mocker.patch("dc_etl.filespec.fsspec")
 
-        fetcher = filespec.File._load_yaml(loader, node)
+        fetcher = filespec.FileSpec._load_yaml(loader, node)
         assert fetcher.fs is fsspec.filesystem.return_value
         assert fetcher.path == "path/to/some/where"
 
@@ -54,7 +54,7 @@ class TestFileSpec:
         node = object()
         fsspec = mocker.patch("dc_etl.filespec.fsspec")
 
-        fetcher = filespec.File._load_yaml(loader, node)
+        fetcher = filespec.FileSpec._load_yaml(loader, node)
         assert fetcher.fs is fsspec.filesystem.return_value
         assert fetcher.path == "path/to/some/where"
 
@@ -71,7 +71,7 @@ class TestFileSpec:
         fsspec = mocker.patch("dc_etl.filespec.fsspec")
 
         with pytest.raises(errors.MissingConfigurationError):
-            filespec.File._load_yaml(loader, node)
+            filespec.FileSpec._load_yaml(loader, node)
 
         loader.construct_mapping.assert_called_once_with(node)
         fsspec.filesystem.assert_not_called()
@@ -79,14 +79,14 @@ class TestFileSpec:
     @staticmethod
     def test_constructor():
         fs = object()
-        file = filespec.File(fs, "some/thing/some/where")
+        file = filespec.FileSpec(fs, "some/thing/some/where")
         assert file.fs is fs
         assert file.path == "some/thing/some/where"
 
     @staticmethod
     def test___div__():
         fs = object()
-        file = filespec.File(fs, "some/thing/some/where/") / "over" / "there"
+        file = filespec.FileSpec(fs, "some/thing/some/where/") / "over" / "there"
         assert file.fs is fs
         assert file.path == "some/thing/some/where/over/there"
 
@@ -94,7 +94,7 @@ class TestFileSpec:
     def test_open(tmpdir):
         """Integration test for read/write with a real filesystem."""
         fs = fsspec.filesystem("file")
-        folder = filespec.File(fs, str(tmpdir))
+        folder = filespec.FileSpec(fs, str(tmpdir))
         file = folder / "foo.txt"
         assert not file.exists()
         with file.open("w") as f:
@@ -105,43 +105,43 @@ class TestFileSpec:
 
     @staticmethod
     def test_with_suffix():
-        file = filespec.File(None, "some/thing.foo").with_suffix("bar")
+        file = filespec.FileSpec(None, "some/thing.foo").with_suffix("bar")
         assert file.path == "some/thing.bar"
 
     @staticmethod
     def test_with_suffix_no_suffix():
-        file = filespec.File(None, "some/thing").with_suffix(".bar")
+        file = filespec.FileSpec(None, "some/thing").with_suffix(".bar")
         assert file.path == "some/thing.bar"
 
     @staticmethod
     def test_with_suffix_no_suffix_but_dot_in_parent():
-        file = filespec.File(None, "so.me/thing").with_suffix("bar")
+        file = filespec.FileSpec(None, "so.me/thing").with_suffix("bar")
         assert file.path == "so.me/thing.bar"
 
     @staticmethod
     def test_name():
-        assert filespec.File(None, "some/thing").name == "thing"
+        assert filespec.FileSpec(None, "some/thing").name == "thing"
 
     @staticmethod
     def test_name_no_parent():
-        assert filespec.File(None, "thing").name == "thing"
+        assert filespec.FileSpec(None, "thing").name == "thing"
 
     @staticmethod
     def test_parent():
-        assert filespec.File(None, "/some/path/to/file").parent.path == "/some/path/to"
+        assert filespec.FileSpec(None, "/some/path/to/file").parent.path == "/some/path/to"
 
     @staticmethod
     def test_parent_trailing_slash():
-        assert filespec.File(None, "/some/path/to/file/").parent.path == "/some/path/to"
+        assert filespec.FileSpec(None, "/some/path/to/file/").parent.path == "/some/path/to"
 
     @staticmethod
     def test_parent_no_parent():
-        assert filespec.File(None, "file").parent is None
+        assert filespec.FileSpec(None, "file").parent is None
 
     @staticmethod
     def test_parent_root():
-        assert filespec.File(None, "/").parent is None
+        assert filespec.FileSpec(None, "/").parent is None
 
     @staticmethod
     def test_parent_in_root():
-        assert filespec.File(None, "/some").parent.path == "/"
+        assert filespec.FileSpec(None, "/some").parent.path == "/"


### PR DESCRIPTION
I found using the standard constructor for `filespec.FileSpec` to be a little clunky, so I introduced a less verbose factory function, `filespec.file` that can be used instead.