### PR TITLE
feat: allow extractor to return multiple single zarr jsons

### DIFF
--- a/dc_etl/extract.py
+++ b/dc_etl/extract.py
@@ -1,4 +1,5 @@
 import abc
+import typing
 
 from dc_etl.filespec import FileSpec
 
@@ -7,8 +8,8 @@ class Extractor(abc.ABC):
     """Responsible for taking a raw source file and turning it into a single Zarr JSON."""
 
     @abc.abstractmethod
-    def __call__(self, source: FileSpec) -> FileSpec:
-        """Extract a source data file into a single Zarr JSON file.
+    def __call__(self, source: FileSpec) -> typing.Generator[FileSpec, None, None]:
+        """Extract a source data file into one or more single Zarr JSON files.
 
         Parameters
         ----------

--- a/dc_etl/extractors/netcdf.py
+++ b/dc_etl/extractors/netcdf.py
@@ -1,3 +1,5 @@
+import typing
+
 import orjson
 
 from kerchunk import hdf
@@ -24,7 +26,7 @@ class NetCDFExtractor(Extractor):
         self.output_folder = output_folder
         self.inline_threshold = inline_threshold
 
-    def __call__(self, source: FileSpec) -> FileSpec:
+    def __call__(self, source: FileSpec) -> typing.Generator[FileSpec, None, None]:
         """Implementation of :meth:`Extractor.extract`"""
         if self.output_folder:
             dest = (self.output_folder / source.name).with_suffix("json")
@@ -36,4 +38,4 @@ class NetCDFExtractor(Extractor):
             with dest.open("wb") as f_out:
                 f_out.write(orjson.dumps(zarr_json.translate()))
 
-        return dest
+        yield dest

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -15,6 +15,7 @@ Options:
 
 import code
 import datetime
+import itertools
 import pdb
 import sys
 
@@ -77,7 +78,7 @@ def run_pipeline(pipeline, span, load):
         f"to {span.end.astype('<M8[s]').astype(object):%Y-%m-%d}"
     )
     sources = pipeline.fetcher.fetch(span)
-    extracted = [pipeline.extractor(source) for source in sources]
+    extracted = list(itertools.chain(*[pipeline.extractor(source) for source in sources]))
     combined = pipeline.transformer(pipeline.combiner(extracted))
     load(combined, span)
 

--- a/examples/cpc_global_precip.py
+++ b/examples/cpc_global_precip.py
@@ -42,7 +42,7 @@ def main():
             "ipld", time_dim="time", publisher=component.ipld_publisher("local_file", CACHE / "zarr_head.cid")
         ),
     )
-p
+
     cli.main(pipeline)
 
 

--- a/tests/system/extractors/test_netcdf.py
+++ b/tests/system/extractors/test_netcdf.py
@@ -1,3 +1,5 @@
+import itertools
+
 import pytest
 import xarray
 
@@ -15,7 +17,7 @@ class TestNetCDFExtractor:
         span = Timespan(npdate(1982, 11, 29), npdate(1984, 6, 25))  # Thriller, Purple Rain
         sources = CPCFetcher("us_precip", cache).fetch(span)
         extractor = NetCDFExtractor()
-        zarr_jsons = list(map(extractor, sources))
+        zarr_jsons = list(itertools.chain(*map(extractor, sources)))
         datasets = [open_dataset(zarr_json) for zarr_json in zarr_jsons]
 
         assert len(datasets) == 3
@@ -35,7 +37,7 @@ class TestNetCDFExtractor:
         span = Timespan(npdate(1982, 11, 29), npdate(1984, 6, 25))  # Thriller, Purple Rain
         sources = CPCFetcher("us_precip", cache).fetch(span)
         extractor = NetCDFExtractor(output_folder=output)
-        zarr_jsons = list(map(extractor, sources))
+        zarr_jsons = list(itertools.chain(*map(extractor, sources)))
         datasets = [open_dataset(zarr_json) for zarr_json in zarr_jsons]
 
         assert len(datasets) == 3
@@ -63,7 +65,7 @@ class TestNetCDFExtractor:
         span = Timespan(npdate(1982, 11, 29), npdate(1984, 6, 25))  # Thriller, Purple Rain
         sources = CPCFetcher("us_precip").fetch(span)
         extractor = NetCDFExtractor(output_folder=output)
-        zarr_jsons = list(map(extractor, sources))
+        zarr_jsons = list(itertools.chain(*map(extractor, sources)))
         datasets = [open_dataset(zarr_json) for zarr_json in zarr_jsons]
 
         assert len(datasets) == 3

--- a/tests/system/pipelines/test_cpc.py
+++ b/tests/system/pipelines/test_cpc.py
@@ -1,6 +1,7 @@
 """Test something a lot like a real pipeline for CPC.
 """
 
+import itertools
 import numcodecs
 
 from dc_etl.fetch import Timespan
@@ -17,7 +18,7 @@ def test_declarative_configuration():
     # Initial dataset
     span = Timespan(npdate(1982, 11, 29), npdate(1984, 6, 25))  # Thriller, Purple Rain
     sources = pipeline.fetcher.fetch(span)
-    extracted = [pipeline.extractor(source) for source in sources]
+    extracted = list(itertools.chain(*[pipeline.extractor(source) for source in sources]))
     dataset = pipeline.combiner(extracted)
     dataset = pipeline.transformer(dataset)
     pipeline.loader.initial(dataset, span)
@@ -30,7 +31,7 @@ def test_declarative_configuration():
     # Append some more data
     span = Timespan(npdate(1984, 6, 26), npdate(1985, 9, 30))  # Purple Rain, Rain Dogs
     sources = pipeline.fetcher.fetch(span)
-    extracted = [pipeline.extractor(source) for source in sources]
+    extracted = list(itertools.chain(*[pipeline.extractor(source) for source in sources]))
     dataset = pipeline.combiner(extracted)
     dataset = pipeline.transformer(dataset)
     pipeline.loader.append(dataset, span)
@@ -43,7 +44,7 @@ def test_declarative_configuration():
     date = npdate(1984, 12, 25)
     span = Timespan(date, date)
     sources = pipeline.fetcher.fetch(span)
-    extracted = [pipeline.extractor(source) for source in sources]
+    extracted = list(itertools.chain(*[pipeline.extractor(source) for source in sources]))
     dataset = pipeline.combiner(extracted)
     dataset = pipeline.transformer(dataset)
 

--- a/tests/system/test_combine.py
+++ b/tests/system/test_combine.py
@@ -1,3 +1,5 @@
+import itertools
+
 from dc_etl import component
 from dc_etl.fetch import Timespan
 
@@ -10,7 +12,7 @@ class TestDefaultCombiner:
         span = Timespan(npdate(1982, 11, 29), npdate(1984, 6, 25))  # Thriller, Purple Rain
         sources = component.fetcher("cpc", "us_precip", cache=cache).fetch(span)
         extractor = component.extractor("netcdf")
-        zarr_jsons = list(map(extractor, sources))
+        zarr_jsons = list(itertools.chain(*map(extractor, sources)))
         multizarr = cache / "combined"
         combine = component.combiner(
             "default",

--- a/tests/system/test_transform.py
+++ b/tests/system/test_transform.py
@@ -1,3 +1,5 @@
+import itertools
+
 from dc_etl import component
 from dc_etl.fetch import Timespan
 
@@ -10,7 +12,7 @@ class TestCompositeTransformer:
         span = Timespan(npdate(1982, 11, 29), npdate(1984, 6, 25))  # Thriller, Purple Rain
         sources = component.fetcher("cpc", "us_precip", cache=cache).fetch(span)
         extractor = component.extractor("netcdf")
-        zarr_jsons = list(map(extractor, sources))
+        zarr_jsons = list(itertools.chain(*map(extractor, sources)))
         multizarr = cache / "cpc" / "us_precip" / "combined-cpc-us-precip-1982-1984.json"
         combine = component.combiner(
             "default",

--- a/tests/unit/extractors/test_netcdf.py
+++ b/tests/unit/extractors/test_netcdf.py
@@ -28,7 +28,7 @@ class TestNetCDFExtractor:
         src = mock_source.open.return_value.__enter__.return_value
 
         extractor = NetCDFExtractor()
-        extracted = extractor(mock_source)
+        extracted = next(extractor(mock_source))
 
         assert orjson.loads(extracted.open().read()) == {"hi": "mom"}
         assert extracted.path == "/data/file.json"
@@ -46,7 +46,7 @@ class TestNetCDFExtractor:
         src = mock_source.open.return_value.__enter__.return_value
 
         extractor = NetCDFExtractor(output_folder=output, inline_threshold=42)
-        extracted = extractor(mock_source)
+        extracted = next(extractor(mock_source))
 
         assert orjson.loads(extracted.open().read()) == {"hi": "mom"}
         assert extracted.path == "/extracted/file.json"


### PR DESCRIPTION
It came up during the presentation with Arbol that they need the ability to return multiple zarr jsons from a single source file. Since allowing for that involves modifying the contract provided by the Extractor interface, it made sense to go ahead and make that change now, since the more things that get built on top of them, the harder it is to change a core interface specification.